### PR TITLE
Adjust device open call permissions

### DIFF
--- a/utp_com.c
+++ b/utp_com.c
@@ -228,7 +228,7 @@ int main(int argc, char * argv[])
 	}
 
 	// Open device
-	device_fd = open(device_name, O_RDWR);
+	device_fd = open(device_name, O_RDONLY);
 	if (device_fd < 0)
 	{
 		fprintf(stderr, "Error opening device: %s\n", device_name);


### PR DESCRIPTION
Since only ioctl calls are used, restrict the permissions to O_RDONLY.

This is necessary since last versions of imx-uuc use a fat partition
and system complains about opening this device with O_RDWR.

Signed-off-by: Gary Bisson gary.bisson@boundarydevices.com
