### PR TITLE
Added error if malloc fails on file load

### DIFF
--- a/utp_com.c
+++ b/utp_com.c
@@ -195,6 +195,12 @@ int main(int argc, char * argv[])
 		// Allocate memory
 		file_data = malloc(st.st_size);
 
+		if (file_data == 0)
+		{
+			fprintf(stderr, "Memory allocation failed; Please ensure your VM has at least 3GB of memory\n");
+			return 1;
+		}
+
 		// Open file
 		file_fd = open(file_name, O_RDONLY);
 		if (file_fd < 0)


### PR DESCRIPTION
For large files [like SDCard images], malloc can fail silently due to insufficient resources. I have added a check for when this happens to exit and notify the user.

The error message itself probably should just be "Memory allocation failed" for general use.